### PR TITLE
Adds the "GitHub Skills" activity to the GitHub server database and settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+    "chat.mcp.serverSampling": {
+        "skills-integrate-mcp-with-copilot/.vscode/mcp.json: github": {
+            "allowedModels": [
+                "copilot/auto",
+                "copilot/claude-haiku-4.5",
+                "copilot/claude-opus-4.5",
+                "copilot/claude-sonnet-4.5",
+                "copilot/gemini-3-flash-preview",
+                "copilot/gemini-3-pro-preview",
+                "copilot/gpt-4.1",
+                "copilot/gpt-5-mini",
+                "copilot/gpt-5-codex",
+                "copilot/gpt-5.1",
+                "copilot/gpt-5.1-codex",
+                "copilot/gpt-5.1-codex-max",
+                "copilot/gpt-5.1-codex-mini",
+                "copilot/gpt-5.2",
+                "copilot/gpt-5.2-codex",
+                "copilot/grok-code-fast-1",
+                "copilot/oswe-vscode-prime"
+            ]
+        }
+    }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Wednesdays, 3:00 PM - 4:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This pull request introduces configuration improvements and a new course to the application. The main changes include updating the VSCode settings to specify allowed Copilot models for server sampling, and adding a new "GitHub Skills" course to the course list.

Configuration updates:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R25): Added a `chat.mcp.serverSampling` configuration specifying a list of allowed Copilot models for the GitHub integration, enhancing control over which models can be used.

Course management:

* [`src/app.py`](diffhunk://#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00R77-R82): Added a new "GitHub Skills" course with a description, schedule, maximum participants, and an empty participants list, expanding the available courses in the application.